### PR TITLE
Additional compile time check + comments

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1226,13 +1226,21 @@ void serializeValue(S, V)(ref S serializer, auto ref V value)
 		auto state = serializer.objectBegin();
 		foreach(member; __traits(allMembers, V))
 		{
+			import std.traits : isFunction;
 			static if(
+				// check if we can read and write this member
 				(__traits(compiles, __traits(getMember, value, member) = __traits(getMember, value, member))
 				||
+					// check if we can read this member
 					__traits(compiles, { auto _val = __traits(getMember, value, member); })
 					&&
+					// is it a function
+					isFunction!(typeof(__traits(getMember, value, member)))
+					&&
+					// is it a property also
 					functionAttributes!(__traits(getMember, value, member)) & FunctionAttribute.property)
 				&&
+				// check if this member has no private or package visibility
 				!__traits(getProtection, __traits(getMember, value, member)).privateOrPackage)
 			{
 				enum udas = [getUDAs!(__traits(getMember, value, member), Serialization)];

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1229,18 +1229,21 @@ void serializeValue(S, V)(ref S serializer, auto ref V value)
 			import std.traits : isFunction;
 			static if(
 				// check if we can read and write this member
-				(__traits(compiles, __traits(getMember, value, member) = __traits(getMember, value, member))
+				(__traits(compiles, a1 = __traits(getMember, value, member))
 				||
 					// check if we can read this member
 					__traits(compiles, { auto _val = __traits(getMember, value, member); })
 					&&
-					// is it a function
-					isFunction!(typeof(__traits(getMember, value, member)))
-					&&
-					// is it a property also
-					functionAttributes!(__traits(getMember, value, member)) & FunctionAttribute.property)
+					// check if the member isn't a function or if it is a function than
+					// it is a property
+					(
+						!isFunction!(typeof(__traits(getMember, value, member)))
+						||
+						// and this member is a property
+						functionAttributes!(__traits(getMember, value, member)) & FunctionAttribute.property)
+					)
 				&&
-				// check if this member has no private or package visibility
+				// check if this member has a private or package visibility
 				!__traits(getProtection, __traits(getMember, value, member)).privateOrPackage)
 			{
 				enum udas = [getUDAs!(__traits(getMember, value, member), Serialization)];


### PR DESCRIPTION
Add check for Aggregate members to be function before checking is it property because `enum` in the Aggregate could be read too but fails checking for being property with cryptic compile time error about wrong function attributes (`enum` isn't function of course).
That let me serialize automatically all my data structures I couldn't before.