### PR TITLE
[WIP] Additional compile time check + comments

### DIFF
--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1289,7 +1289,10 @@ void serializeValue(S, T)(ref S serializer, T[] value)
 
 /// Input range serialization
 void serializeValue(S, R)(ref S serializer, R value) 
-	if ((isInputRange!R) && !isSomeChar!(ElementType!R) && !isDynamicArray!R)
+	if ((isInputRange!R) && 
+		!isSomeChar!(ElementType!R) && 
+		!isDynamicArray!R &&
+		!isNullable!R)
 {
 	auto state = serializer.arrayBegin();
 	foreach (ref elem; value)

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -187,7 +187,7 @@ unittest
 				return false;
 
 			return my_nullable == rhs.my_nullable && 
-				         field == rhs.field;
+						 field == rhs.field;
 		}
 	}
 
@@ -219,7 +219,7 @@ unittest
 				return false;
 
 			return nullable == rhs.nullable && 
-				         field == rhs.field;
+						 field == rhs.field;
 		}
 	}
 
@@ -1870,24 +1870,24 @@ void deserializeValue(V : T[E], T, E)(Asdf data, ref V value)
 
 /// Deserialize associative array with integral type key
 void deserializeValue(V : T[K], T, K)(Asdf data, ref V value)
-    if((isIntegral!K) && !is(K == enum))
+	if((isIntegral!K) && !is(K == enum))
 {
-    auto kind = data.kind;
-    with(Asdf.Kind) switch(kind)
-    {
-        case object:
-            foreach(elem; data.byKeyValue)
-            {
-                T v;
-                .deserializeValue(elem.value, v);
-                value[elem.key.to!K] = v;
-            }
-            return;
-        case null_:
-            return;
-        default:
-            throw new DeserializationException(kind);
-    }
+	auto kind = data.kind;
+	with(Asdf.Kind) switch(kind)
+	{
+		case object:
+			foreach(elem; data.byKeyValue)
+			{
+				T v;
+				.deserializeValue(elem.value, v);
+				value[elem.key.to!K] = v;
+			}
+			return;
+		case null_:
+			return;
+		default:
+			throw new DeserializationException(kind);
+	}
 }
 
 ///

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1233,6 +1233,12 @@ void serializeValue(S)(ref S serializer, bool value)
 	serializer.putValue(value);
 }
 
+/// Char serialization
+void serializeValue(S)(ref S serializer, char value)
+{
+	serializer.putValue([value]);
+}
+
 ///
 unittest
 {
@@ -1828,6 +1834,13 @@ void deserializeValue(V)(Asdf data, ref V value)
 		default:
 			throw new DeserializationException(kind);
 	}
+}
+
+/// Deserialize single char
+void deserializeValue(V)(Asdf data, V value) if (is (V : char))
+{
+	auto v = cast(char[1])[value];
+	deserializeValue(data, v);
 }
 
 ///

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -335,8 +335,8 @@ string serializeToJsonPretty(string sep = "\t", V)(auto ref V value)
 ///
 unittest
 {
-    static struct S { int a; }
-    assert(S(4).serializeToJsonPretty == "{\n\t\"a\": 4\n}");
+	static struct S { int a; }
+	assert(S(4).serializeToJsonPretty == "{\n\t\"a\": 4\n}");
 }
 
 /// ASDF serialization function
@@ -1036,9 +1036,7 @@ unittest
 	
 	ser.objectEnd(state0);
 	ser.flush;
-
-	import std.stdio;
-
+	
 	assert(app.data == 
 `{
 	"null": null,
@@ -1804,7 +1802,7 @@ void deserializeValue(V : T[E], T, E)(Asdf data, ref V value)
 	}
 }
 
-/// Deserialize enumeration-value associative array
+/// Deserialize associative array with integral type key
 void deserializeValue(V : T[K], T, K)(Asdf data, ref V value)
     if((isIntegral!K) && !is(K == enum))
 {
@@ -1829,11 +1827,10 @@ void deserializeValue(V : T[K], T, K)(Asdf data, ref V value)
 ///
 unittest
 {
-	enum E {a, b}
-	assert(deserialize!(int[E])(serializeToJson(null)) is null);
-	assert(deserialize!(int[E])(serializeToAsdf(null)) is null);
-	assert(deserialize!(int[E])(serializeToJson([E.a : 1, E.b : 2])) == [E.a : 1, E.b : 2]);
-	assert(deserialize!(int[E])(serializeToAsdf([E.a : 1, E.b : 2])) == [E.a : 1, E.b : 2]);
+	assert(deserialize!(int[int])(serializeToJson(null)) is null);
+	assert(deserialize!(int[int])(serializeToAsdf(null)) is null);
+	assert(deserialize!(int[int])(serializeToJson([2 : 1, 40 : 2])) == [2 : 1, 40 : 2]);
+	assert(deserialize!(int[int])(serializeToAsdf([2 : 1, 40 : 2])) == [2 : 1, 40 : 2]);
 }
 
 /// Deserialize Nullable value
@@ -1867,6 +1864,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 		{
 			throw new DeserializationException(kind);
 		}
+
 		static if(is(V == class) || is(V == interface))
 		{
 			if(value is null)
@@ -1881,6 +1879,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 				}
 			}
 		}
+
 		foreach(elem; data.byKeyValue)
 		{
 			switch(elem.key)
@@ -1913,6 +1912,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 				case key:
 
 							}
+
 							static if(!proper)
 							{
 								alias Type = Parameters!(__traits(getMember, value, member));
@@ -1921,6 +1921,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 							{
 								alias Type = typeof(__traits(getMember, value, member));
 							}
+
 							static if(isLikeArray(V.stringof, member, udas))
 							{
 								static assert(hasSerializedAs!(__traits(getMember, value, member)), V.stringof ~ "." ~ member ~ " should have a Proxy type for deserialization");
@@ -1955,10 +1956,9 @@ void deserializeValue(V)(Asdf data, ref V value)
 								enum S = isScoped(V.stringof, member, udas) && __traits(compiles, .deserializeScopedString(elem.value, proxy));
 								alias Fun = Select!(F, Flex, Select!(S, .deserializeScopedString, .deserializeValue));
 						
-					Proxy proxy;
-					Fun(elem.value, proxy);
-					__traits(getMember, value, member) = proxy.to!Type;
-
+								Proxy proxy;
+								Fun(elem.value, proxy);
+								__traits(getMember, value, member) = proxy.to!Type;
 							}
 							else
 							static if(proper && __traits(compiles, {auto ptr = &__traits(getMember, value, member); }))
@@ -1966,25 +1966,23 @@ void deserializeValue(V)(Asdf data, ref V value)
 								enum S = isScoped(V.stringof, member, udas) && __traits(compiles, .deserializeScopedString(elem.value, __traits(getMember, value, member)));
 								alias Fun = Select!(F, Flex, Select!(S, .deserializeScopedString, .deserializeValue));
 
-					Fun(elem.value, __traits(getMember, value, member));
-
+								Fun(elem.value, __traits(getMember, value, member));
 							}
 							else
 							{
-					Type val;
+								Type val;
 
 								enum S = isScoped(V.stringof, member, udas) && __traits(compiles, .deserializeScopedString(elem.value, val));
 								alias Fun = Select!(F, Flex, Select!(S, .deserializeScopedString, .deserializeValue));
 
-					Fun(elem.value, val);
-					__traits(getMember, value, member) = val;
-
+								Fun(elem.value, val);
+								__traits(getMember, value, member) = val;
 							}
 
 							static if(hasTransformIn!(__traits(getMember, value, member)))
 							{
 								alias f = unaryFun!(getTransformIn!(__traits(getMember, value, member)));
-					__traits(getMember, value, member) = f(__traits(getMember, value, member));
+								__traits(getMember, value, member) = f(__traits(getMember, value, member));
 							}
 
 					break;
@@ -1995,6 +1993,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 				default:
 			}
 		}
+
 		foreach(member; __traits(allMembers, V))
 		{
 			enum proper = __traits(compiles, __traits(getMember, value, member) = __traits(getMember, value, member));
@@ -2034,6 +2033,7 @@ void deserializeValue(V)(Asdf data, ref V value)
 								{
 									alias Type = typeof(__traits(getMember, value, member));
 								}
+
 								static if(isLikeArray(V.stringof, member, udas))
 								{
 									static assert(hasSerializedAs!(__traits(getMember, value, member)), V.stringof ~ "." ~ member ~ " should have a Proxy type for deserialization");
@@ -2079,7 +2079,6 @@ void deserializeValue(V)(Asdf data, ref V value)
 									alias Fun = Select!(F, Flex, Select!(S, .deserializeScopedString, .deserializeValue));
 
 									Fun(d, __traits(getMember, value, member));
-
 								}
 								else
 								{
@@ -2090,7 +2089,6 @@ void deserializeValue(V)(Asdf data, ref V value)
 
 									Fun(elem.value, val);
 									__traits(getMember, value, member) = val;
-
 								}
 
 								static if(hasTransformIn!(__traits(getMember, value, member)))

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1953,6 +1953,10 @@ void deserializeValue(V : T[N], T, size_t N)(Asdf data, ref V value)
 	auto kind = data.kind;
 	with(Asdf.Kind) switch(kind)
 	{
+static if(is(T == char))
+{
+		case string:
+}
 		case array:
 			auto elems = data.byElement;
 			foreach(ref e; value)

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1287,6 +1287,38 @@ void serializeValue(S, T)(ref S serializer, T[] value)
 	serializer.arrayEnd(state);
 }
 
+/// Input range serialization
+void serializeValue(S, R)(ref S serializer, R value) 
+	if ((isInputRange!R) && !isSomeChar!(ElementType!R) && !isDynamicArray!R)
+{
+	auto state = serializer.arrayBegin();
+	foreach (ref elem; value)
+	{
+		serializer.elemBegin;
+		serializer.serializeValue(elem);
+	}
+	serializer.arrayEnd(state);
+}
+
+/// input range serialization
+unittest
+{
+	import std.algorithm : filter;
+
+	struct Foo
+	{
+		int i;
+	}
+
+	auto ar = [Foo(1), Foo(3), Foo(4), Foo(17)];
+	
+	auto filtered1 = ar.filter!"a.i & 1";
+	auto filtered2 = ar.filter!"!(a.i & 1)";
+
+	assert(serializeToJson(filtered1) == `[{"i":1},{"i":3},{"i":17}]`);
+	assert(serializeToJson(filtered2) == `[{"i":4}]`);
+}
+
 ///
 unittest
 {
@@ -1399,7 +1431,7 @@ void serializeValue(S, N)(ref S serializer, auto ref N value)
 
 /// Aggregation type serialization
 void serializeValue(S, V)(ref S serializer, auto ref V value)
-	if(!isNullable!V && isAggregateType!V && !is(V : BigInt))
+	if(!isNullable!V && isAggregateType!V && !is(V : BigInt) && !isInputRange!V)
 {
 	static if(is(V == class) || is(V == interface))
 	{

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1642,7 +1642,21 @@ void serializeValue(S, V)(ref S serializer, auto ref V value)
 					}
 					else
 					{
-						serializer.serializeValue(cast()val);
+						static if (isNullable!(typeof(cast()val)))
+						{
+							if(val.isNull)
+							{
+								serializer.putValue(null);
+							}
+							else
+							{
+								serializer.serializeValue(val.get);
+							}
+						}
+						else
+						{
+							.serializeValue(serializer, cast() val);
+						}
 					}
 				}
 			}

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -2587,7 +2587,7 @@ private template hasProtection(alias Aggregate, alias member)
 
 private template isMemberSomeProperty(alias Kind, alias Aggregate, alias member)
 {
-	import std.traits : isCallable, isType, isTypeTuple;
+	import std.traits : isCallable, isTypeTuple;
 
 	// TODO isn't direct using 'this' a hack?
 	static if (member == "this" || 

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1893,7 +1893,8 @@ void deserializeValue(V : T[], T)(Asdf data, ref V value)
 			value = null;
 			return;
 		default:
-			throw new DeserializationException(kind);
+			import std.conv : text;
+			throw new DeserializationException(kind, "Json array expected but `" ~ text(cast(Asdf.Kind)kind) ~ "` given");
 	}
 }
 

--- a/source/asdf/serialization.d
+++ b/source/asdf/serialization.d
@@ -1369,7 +1369,7 @@ void serializeValue(S, T, K)(ref S serializer, auto ref T[K] value)
 		import std.format : sformat;
 		auto str = sformat(buffer[], "%d", key);
 		serializer.putEscapedKey(str);
-		serializer.putValue(val);
+		.serializeValue(serializer, val);
 	}
 	serializer.objectEnd(state);
 }
@@ -1814,6 +1814,17 @@ unittest
 	assert(deserialize!(int[4])(serializeToAsdf([1, 3, 4])) == [1, 3, 4, 0]);
 	assert(deserialize!(int[2])(serializeToJson([1, 3, 4])) == [1, 3]);
 	assert(deserialize!(int[2])(serializeToAsdf([1, 3, 4])) == [1, 3]);
+}
+
+/// AA with value of aggregate type
+unittest
+{
+	struct Foo
+	{
+		
+	}
+
+	assert (deserialize!(Foo[int])(serializeToJson([1: Foo()])) == [1:Foo()]);
 }
 
 /// Deserialize string-value associative array


### PR DESCRIPTION
Add check for Aggregate members to be function before checking is it property because `enum` in the Aggregate could be read but fails checking for being property with cryptic compile time error about wrong function attributes (`enum` isn't function of course).
That let me serialize automatically all my data structures I couldn't before.